### PR TITLE
Fix migration

### DIFF
--- a/migrations/m171015_085210_flysystem_wrapper.php
+++ b/migrations/m171015_085210_flysystem_wrapper.php
@@ -25,9 +25,9 @@ class m171015_085210_flysystem_wrapper extends Migration
             'context' => $this->string(100)->null(),
             'version' => $this->integer()->null(),
             'hash' => $this->string(64)->notNull()->unique(),
-            'uploaded_time' => $this->timestamp(),
+            'uploaded_time' => $this->timestamp()->null(),
             'uploaded_user_id' => $this->integer(),
-            'deleted_time' => $this->timestamp(),
+            'deleted_time' => $this->timestamp()->null(),
         ], $tableOptions);
 
         $this->createTable('{{%file_metadata}}', [
@@ -35,8 +35,8 @@ class m171015_085210_flysystem_wrapper extends Migration
             'file_id' => $this->integer()->notNull(),
             'metadata' => $this->string(255)->notNull(),
             'value' => $this->string(255)->notNull(),
-            'created_time' => $this->timestamp(),
-            'deleted_time' => $this->timestamp(),
+            'created_time' => $this->timestamp()->null(),
+            'deleted_time' => $this->timestamp()->null(),
         ], $tableOptions);
 
         $this->createTable('{{%file_storage}}', [
@@ -47,11 +47,10 @@ class m171015_085210_flysystem_wrapper extends Migration
             'size' => $this->integer()->notNull()->defaultValue(0),
             'mimetype' => $this->string(127),
             'timestamp' => $this->integer()->notNull()->defaultValue(0),
-            'deleted_time' => $this->timestamp(),
+            'deleted_time' => $this->timestamp()->null(),
         ], $tableOptions);
 
         $this->addForeignKey('fk_file_metadata', '{{%file_metadata}}', 'file_id', '{{%file}}', 'id');
-        $this->addForeignKey('fk_file_uploaded_user_id', '{{%file}}', 'uploaded_user_id', '{{%user}}', 'id');
     }
 
     public function safeDown()


### PR DESCRIPTION
Make timestamp columns nullable as in MySQL 5.7 strict mode became the
default, so timestamps should have a valid default value or be nullable.
It generates the following error:
```
Exception: SQLSTATE[42000]: Syntax error or access violation: 1067 Invalid default value for 'deleted_time'
```

Remove foreign key for uploaded_user_id column as you should not rely on
the existence of user table, default yii2 installation doesn't have user
table.
